### PR TITLE
Made CharsetEncoder/Decoder thread-safe

### DIFF
--- a/src/main/scala/com/shorrockin/cascal/utils/ThreadLocal.scala
+++ b/src/main/scala/com/shorrockin/cascal/utils/ThreadLocal.scala
@@ -1,0 +1,11 @@
+package com.shorrockin.cascal.utils
+
+/**
+ * utility class to make java.lang.ThreadLocal easier to use
+ * courtesy to mehack (http://mehack.com/)
+ */
+class ThreadLocal[T](init: => T) extends java.lang.ThreadLocal[T] with Function0[T] {
+  override def initialValue:T = init
+  def apply = get
+  def withValue[S](thunk:(T => S)):S = thunk(get)
+}


### PR DESCRIPTION
I saw transient errors such as:

```
failed: Current state = RESET, new state = FLUSHED
```

or

```
failed: Current state = CODING_END, new state = FLUSHED
```

when running `sbt test`.

Turns out it caused by `CharsetEncoder/Decoder`, called in `Serializer.scala`. They are not thread-safe. The patch wraps them in a Scala `DynamicVariable` so they are thread-local variables and can be safely called from multiple threads.

After applied the patch, `sbt test` consistently succeeds now.
