### PR TITLE
Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.3-SNAPSHOT"
 
 organization := "com.shorrockin"
 
-scalaVersion := "2.9.2"
+scalaVersion := "2.10.1"
 
 compileOrder := CompileOrder.JavaThenScala
 

--- a/src/main/scala/com/shorrockin/cascal/model/Column.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/Column.scala
@@ -84,7 +84,7 @@ case class Column[Owner](val name:ByteBuffer,
     if (a == null) return "NULL"
     if (a.array.length <= 4) return "Array (" + a.array.mkString(", ") + ")"
     if (a.array.length > 1000) return a.array.toString
-    try { Conversions.string(a) } catch { case _ => a.array.toString }
+    try { Conversions.string(a) } catch { case _:Throwable => a.array.toString }
   }
   
   def cassandraColumn(): CassColumn = {

--- a/src/main/scala/com/shorrockin/cascal/model/SuperColumn.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/SuperColumn.scala
@@ -27,7 +27,7 @@ case class SuperColumn(val value:ByteBuffer, val key:SuperKey) extends Gettable[
   def ::(other:SuperColumn):List[SuperColumn] = other :: this :: Nil
 
   private def convertList[T](v:java.util.List[T]):List[T] = {
-	 scala.collection.JavaConversions.asBuffer(v).toList
+	 scala.collection.JavaConversions.asScalaBuffer(v).toList
   }
 
   /**

--- a/src/main/scala/com/shorrockin/cascal/model/SuperColumn.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/SuperColumn.scala
@@ -54,7 +54,7 @@ case class SuperColumn(val value:ByteBuffer, val key:SuperKey) extends Gettable[
   private def stringIfPossible(a:ByteBuffer):String = {
     if (a.array.length <= 4) return "Array (" + a.array.mkString(", ") + ")"
     if (a.array.length > 1000) return a.array.toString
-    try { Conversions.string(a) } catch { case _ => a.array.toString }
+    try { Conversions.string(a) } catch { case _:Throwable => a.array.toString }
   }
 
   override def toString():String = "%s \\ SuperColumn(value = %s)".format(

--- a/src/main/scala/com/shorrockin/cascal/model/SuperKey.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/SuperKey.scala
@@ -22,7 +22,7 @@ case class SuperKey(val value:String, val family:SuperColumnFamily) extends Key[
   }
 
   private def convertList[T](v:java.util.List[T]):List[T] = {
-	 scala.collection.JavaConversions.asBuffer(v).toList
+	 scala.collection.JavaConversions.asScalaBuffer(v).toList
   }
 
   override def toString = "%s \\ SuperKey(value = %s)".format(family.toString, value)

--- a/src/main/scala/com/shorrockin/cascal/session/Session.scala
+++ b/src/main/scala/com/shorrockin/cascal/session/Session.scala
@@ -490,18 +490,18 @@ class Session(val host:Host, val defaultConsistency:Consistency, val noFramedTra
   }
 
   private def Buffer[T](v:java.util.List[T]) = {
-    scala.collection.JavaConversions.asBuffer(v)
+    scala.collection.JavaConversions.asScalaBuffer(v)
   }
 
   implicit private def convertList[T](v:java.util.List[T]):List[T] = {
-    scala.collection.JavaConversions.asBuffer(v).toList
+    scala.collection.JavaConversions.asScalaBuffer(v).toList
   }
 
   implicit private def convertMap[K,V](v:java.util.Map[K,V]): scala.collection.mutable.Map[K,V] = {
-    scala.collection.JavaConversions.asMap(v)
+    scala.collection.JavaConversions.mapAsScalaMap(v)
   }
 
   implicit private def convertSet[T](s:java.util.Set[T]):scala.collection.mutable.Set[T] = {
-    scala.collection.JavaConversions.asSet(s)
+    scala.collection.JavaConversions.asScalaSet(s)
   }
 }


### PR DESCRIPTION
Hi Shimi Kiviti,

Here is a pull request which simply fix deprecation errors so Cascal can be built with Scala 2.10.

This is the initial work to move it toward scala 2.10 since there are still quite a few deprecation and feature warnings.

Initial tests are fine, and I'll let you know if any errors are found.

Wish you a nice day,

Jeanluc
