### PR TITLE
Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,3 +24,5 @@ publishTo <<= (version) { version: String =>
         if  (version.trim.endsWith("SNAPSHOT"))  "snapshots"
         else                                     "releases/" }    ))
 }
+
+scalacOptions ++= Seq("-feature", "-Xlog-implicits")

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ scalaVersion := "2.10.1"
 compileOrder := CompileOrder.JavaThenScala
 
 libraryDependencies ++= Seq(
-    "org.apache.cassandra" % "cassandra-all" %  "1.1.0",
-    "org.apache.cassandra" % "cassandra-thrift" % "1.1.0",
+    "org.apache.cassandra" % "cassandra-all" %  "1.1.10",
+    "org.apache.cassandra" % "cassandra-thrift" % "1.1.10",
 	"com.eaio.uuid" % "uuid" % "3.2",
 	"org.slf4j" % "slf4j-api" % "1.6.4",
 	"commons-pool" % "commons-pool" % "1.6",

--- a/src/main/scala/com/shorrockin/cascal/model/Column.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/Column.scala
@@ -82,7 +82,7 @@ case class Column[Owner](val name:ByteBuffer,
 
   private def stringIfPossible(a:ByteBuffer):String = {
     if (a == null) return "NULL"
-    if (a.array.length <= 4) return "Array (" + a.array.mkString(", ") + ")"
+    if (a.array.length <= 4) return "Array (" + byteArrayOps(a.array).mkString(", ") + ")"
     if (a.array.length > 1000) return a.array.toString
     try { Conversions.string(a) } catch { case _:Throwable => a.array.toString }
   }

--- a/src/main/scala/com/shorrockin/cascal/model/IndexQuery.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/IndexQuery.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal.model
 
+import scala.language.implicitConversions
 import org.apache.cassandra.thrift.IndexClause
 import java.nio.ByteBuffer
 import org.apache.cassandra.thrift.{IndexExpression => CassIndexExpression}

--- a/src/main/scala/com/shorrockin/cascal/model/SuperColumn.scala
+++ b/src/main/scala/com/shorrockin/cascal/model/SuperColumn.scala
@@ -52,7 +52,7 @@ case class SuperColumn(val value:ByteBuffer, val key:SuperKey) extends Gettable[
   }
 
   private def stringIfPossible(a:ByteBuffer):String = {
-    if (a.array.length <= 4) return "Array (" + a.array.mkString(", ") + ")"
+    if (a.array.length <= 4) return "Array (" + byteArrayOps(a.array).mkString(", ") + ")"
     if (a.array.length > 1000) return a.array.toString
     try { Conversions.string(a) } catch { case _:Throwable => a.array.toString }
   }

--- a/src/main/scala/com/shorrockin/cascal/serialization/Converter.scala
+++ b/src/main/scala/com/shorrockin/cascal/serialization/Converter.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal.serialization
 
+import scala.language.existentials
 import java.nio.ByteBuffer
 import reflect.Manifest
 import java.lang.annotation.Annotation

--- a/src/main/scala/com/shorrockin/cascal/session/Operation.scala
+++ b/src/main/scala/com/shorrockin/cascal/session/Operation.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal.session
 
+import scala.language.existentials
 import org.apache.cassandra.thrift.{Deletion, Mutation}
 import com.shorrockin.cascal.model._
 import com.shorrockin.cascal.utils.Utils.now

--- a/src/main/scala/com/shorrockin/cascal/session/Session.scala
+++ b/src/main/scala/com/shorrockin/cascal/session/Session.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal.session
 
+import scala.language.implicitConversions
 import scala.collection.mutable
 import collection.immutable.HashSet
 import java.util.concurrent.atomic.AtomicLong

--- a/src/main/scala/com/shorrockin/cascal/utils/Conversions.scala
+++ b/src/main/scala/com/shorrockin/cascal/utils/Conversions.scala
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer
 object Conversions {
   val utf8 = Charset.forName("UTF-8")
 
-  implicit def keyspace(str:String) = new Keyspace(str)
+  implicit def stringToKeyspace(str:String) = new Keyspace(str)
 
   implicit def byteBuffer(date:Date):ByteBuffer = DateSerializer.toByteBuffer(date)
   implicit def date(bytes:ByteBuffer):Date = DateSerializer.fromByteBuffer(bytes)

--- a/src/main/scala/com/shorrockin/cascal/utils/Conversions.scala
+++ b/src/main/scala/com/shorrockin/cascal/utils/Conversions.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal.utils
 
+import scala.language.implicitConversions
 import java.nio.charset.Charset
 import com.shorrockin.cascal.model.{Column, Keyspace}
 import java.util.{Date, UUID => JavaUUID}

--- a/src/main/scala/com/shorrockin/cascal/utils/Utils.scala
+++ b/src/main/scala/com/shorrockin/cascal/utils/Utils.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal.utils
 
+import scala.language.reflectiveCalls
 import _root_.scala.io.Source
 import java.io.{FileWriter, InputStream, FileOutputStream, File}
 import java.util.concurrent.TimeUnit

--- a/src/test/scala/com/shorrockin/cascal/CompositeTest.scala
+++ b/src/test/scala/com/shorrockin/cascal/CompositeTest.scala
@@ -1,5 +1,6 @@
 package com.shorrockin.cascal
 
+import scala.language.implicitConversions
 import org.junit.{Assert, Test}
 import com.shorrockin.cascal.utils.Conversions._
 import com.shorrockin.cascal.serialization.TupleSerializer


### PR DESCRIPTION
Hi Shimi,

Please find in this pull request new changes to make cascal compatible with scala 2.10.

Some changes are specific to scala 2.10 since they rely on specific:
- scalac options,
- scala.language.\* imports.

You can find detailed explanations in each commit logs.

Wish you a nice day,

Jeanluc
